### PR TITLE
componentWillReceiveProps has been renamed, and is not recommended for use

### DIFF
--- a/src/Loading.jsx
+++ b/src/Loading.jsx
@@ -24,12 +24,13 @@ export default class Loading extends Component {
     appearDelayWidth: 0 // when appear, first display block then transition width
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { show, change } = nextProps
+  componentDidUpdate(prevProps) {
+    const { show, change } = this.props
 
-    if (!change) {
+    if (!change || prevProps.show === show) {
       return
     }
+
     if (show) {
       this.show()
     } else {


### PR DESCRIPTION
This component is throwing the following warning:

```
Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: Loading
```
The recommendation is to change to a different lifecycle method. So, I updated this to use `componentDidUpdate` instead. Since the component is changing state, we need to check to see if the state was changed by comparing the prevProps with the currentProps.

This change should do the trick. I tested and all worked as did previously.

This also fixes #8 